### PR TITLE
Kalista Update

### DIFF
--- a/meta Smite/Program.cs
+++ b/meta Smite/Program.cs
@@ -110,8 +110,7 @@ namespace meta_Smite
                                     ObjectManager.Player.ChampionName == "Rengar" ||
                                     ObjectManager.Player.ChampionName == "Nasus" ||
                                     ObjectManager.Player.ChampionName == "LeeSin" ||
-                                    ObjectManager.Player.ChampionName == "Udyr" ||
-                                    ObjectManager.Player.ChampionName == "Kalista")
+                                    ObjectManager.Player.ChampionName == "Udyr")
                                 {
                                     if (ObjectManager.Player.ChampionName == "LeeSin")
                                     {


### PR DESCRIPTION
Updated Kalista, if E dmg is higher than smite damage, it will smite first, then use E, this way u can guarantee the objective with 0 delay (is insanely fast the cast of both spells) between skill and smite, and get the E reset.
